### PR TITLE
Fix: Error when vault names contain spaces

### DIFF
--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -242,8 +242,8 @@ func (c *Client) GetSecret(ctx context.Context, vault, itemReference, fieldLabel
 		// If GetItem failed, fall back to op:// path below
 	}
 
-	// Fallback: Build the op:// item reference using the resolved vault NAME
-	itemRef := fmt.Sprintf("op://%s/%s/%s", vaultInfo.Name, itemReference, fieldLabel)
+	// Fallback: Build the op:// item reference using the resolved vault ID
+	itemRef := fmt.Sprintf("op://%s/%s/%s", vaultInfo.ID, itemReference, fieldLabel)
 	args := []string{"read", itemRef}
 
 	if validateErr := c.executor.ValidateArgs(args); validateErr != nil {


### PR DESCRIPTION
Change vaultInfo.Name -> vaultInfo.ID in GetSecret function.

Fixes errors like the example below:

Error: application execution failed: [OP1302] Secret retrieval failed: failed to retrieve secret for key 'value': secret retrieval failed with exit code 1: [ERROR] 2025/09/23 20:58:58 could not read secret
'op://CI/CD Credentials/oam-oam-controller/password': could not get item CI/CD Credentials: "CI" isn't a vault in this account. Specify the vault with its ID or name.