### PR TITLE
Chore: Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 ---
-# SPDX-FileCopyrightText: 2025 The Linux Foundation
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 version: 2
 updates:
@@ -10,3 +10,11 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "Chore"
+    open-pull-requests-limit: 15
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Chore"
+    open-pull-requests-limit: 15


### PR DESCRIPTION
Add gomod package ecosystem for Go dependency scanning.
Set open-pull-requests-limit on both ecosystems.