### PR TITLE
Fix: resolve Zizmor template and env findings

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,6 +78,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -135,6 +137,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test single secret retrieval (live credentials)"
         id: single-secret
@@ -200,6 +204,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test output return type (live credentials)"
         id: output-test
@@ -227,6 +233,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test invalid vault with live credentials"
         id: invalid-vault
@@ -255,6 +263,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test single secret performance"
         id: perf-single
@@ -304,6 +314,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test secret masking with live credentials"
         id: secret-masking
@@ -332,6 +344,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test complex workflow scenario"
         id: complex
@@ -374,6 +388,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -441,6 +457,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -132,6 +134,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -222,6 +226,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -299,6 +305,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -363,6 +371,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -435,6 +445,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -511,6 +523,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -540,6 +554,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -569,6 +585,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -603,6 +621,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Setup Go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -743,6 +763,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test single secret retrieval (mock)"
         id: single-secret
@@ -794,6 +816,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test output return type (mock)"
         id: output-test
@@ -841,6 +865,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: "Test invalid vault (mock)"
         id: invalid-vault

--- a/action.yaml
+++ b/action.yaml
@@ -129,13 +129,13 @@ runs:
         BINARY_NAME="op-secrets-action-${OS}-${ARCH}"
 
         # Check if custom download URL is provided, otherwise build locally
-        if [ -n "${{ inputs.download_url }}" ]; then
+        if [ -n "$ACTION_DOWNLOAD_URL" ]; then
           echo "::group::Downloading 1Password Secrets Action binary"
-          echo "Download URL: ${{ inputs.download_url }}"
-          curl -fsSL -o "${BINARY_NAME}" "${{ inputs.download_url }}"
+          echo "Download URL: $ACTION_DOWNLOAD_URL"
+          curl -fsSL -o "${BINARY_NAME}" "$ACTION_DOWNLOAD_URL"
 
           # Require checksum when using custom download URL and verify it (cross-platform)
-          if [ -z "${{ inputs.checksum }}" ]; then
+          if [ -z "$ACTION_CHECKSUM" ]; then
             echo "::error::Custom download URL provided but no checksum specified. Please provide the 'checksum' input."
             exit 1
           fi
@@ -148,9 +148,9 @@ runs:
             echo "::error::No SHA-256 tool found (sha256sum or shasum)"
             exit 1
           fi
-          if [ "${ACTUAL_CHECKSUM}" != "${{ inputs.checksum }}" ]; then
+          if [ "${ACTUAL_CHECKSUM}" != "$ACTION_CHECKSUM" ]; then
             echo "::error::Checksum verification failed!"
-            echo "::error::Expected: ${{ inputs.checksum }}"
+            echo "::error::Expected: $ACTION_CHECKSUM"
             echo "::error::Actual: ${ACTUAL_CHECKSUM}"
             exit 1
           fi
@@ -189,17 +189,37 @@ runs:
         # Make executable
         chmod +x "${BINARY_NAME}"
 
-        # Execute the binary with inputs
-        # vault and record are passed via environment variables to avoid shell escaping issues with multiline JSON
-        ./"${BINARY_NAME}" \
-          $([ -n "${{ inputs.return_type }}" ] && echo "--return-type=${{ inputs.return_type }}") \
-          $([ -n "${{ inputs.config_file }}" ] && echo "--config=${{ inputs.config_file }}") \
-          $([ -n "${{ inputs.timeout }}" ] && echo "--timeout=${{ inputs.timeout }}") \
-          $([ -n "${{ inputs.max_concurrency }}" ] && echo "--max-concurrency=${{ inputs.max_concurrency }}") \
-          $([ -n "${{ inputs.cli_version }}" ] && echo "--cli-version=${{ inputs.cli_version }}") \
-          $([ "${{ inputs.cache_enabled }}" = "true" ] && echo "--cache") \
-          $([ "${{ inputs.debug }}" = "true" ] && echo "--debug") \
-          $([ "${{ inputs.mock_mode }}" = "true" ] && echo "--mock")
+        # Execute the binary with inputs.
+        # vault and record are passed via environment variables to avoid shell escaping issues with multiline JSON.
+        # Build the optional flags as an argv array so values such as a
+        # config_file path containing spaces stay a single argument and
+        # are not subject to word-splitting or glob expansion.
+        args=()
+        if [ -n "$OP_RETURN_TYPE" ]; then
+          args+=("--return-type=$OP_RETURN_TYPE")
+        fi
+        if [ -n "$OP_CONFIG_FILE" ]; then
+          args+=("--config=$OP_CONFIG_FILE")
+        fi
+        if [ -n "$OP_TIMEOUT" ]; then
+          args+=("--timeout=$OP_TIMEOUT")
+        fi
+        if [ -n "$OP_MAX_CONCURRENCY" ]; then
+          args+=("--max-concurrency=$OP_MAX_CONCURRENCY")
+        fi
+        if [ -n "$OP_CLI_VERSION" ]; then
+          args+=("--cli-version=$OP_CLI_VERSION")
+        fi
+        if [ "$OP_CACHE_ENABLED" = "true" ]; then
+          args+=("--cache")
+        fi
+        if [ "$DEBUG" = "true" ]; then
+          args+=("--debug")
+        fi
+        if [ "$MOCK_MODE" = "true" ]; then
+          args+=("--mock")
+        fi
+        ./"${BINARY_NAME}" "${args[@]}"
 
         # Clean up the binary
         rm -f "${BINARY_NAME}"


### PR DESCRIPTION
## Summary

Resolves all 41 Zizmor findings reported by the org-wide security audit:
19 × `template-injection` and 22 × `artipacked`.

## Fix

**`action.yaml` — template-injection**

- The `Retrieve 1Password Secrets` step already maps every input to an
  env var in its `env:` block. The `run:` body now references those
  existing env vars (`ACTION_DOWNLOAD_URL`, `ACTION_CHECKSUM`,
  `OP_RETURN_TYPE`, `OP_CONFIG_FILE`, `OP_TIMEOUT`, `OP_MAX_CONCURRENCY`,
  `OP_CLI_VERSION`, `OP_CACHE_ENABLED`, `DEBUG`, `MOCK_MODE`) as quoted
  shell variables instead of interpolating `${{ inputs.* }}` directly.

**`.github/workflows/integration.yaml` + `testing.yaml` — artipacked**

- Set `persist-credentials: false` on every `actions/checkout` step
  (9 in `integration.yaml`, 13 in `testing.yaml`). These workflows
  authenticate to 1Password via repository secrets and never push git,
  so no persisted git credential is required.

Behaviour is preserved.

## Verification

```
uvx zizmor@1.25.2 --persona regular --min-severity medium 1password-secrets-action
# No findings to report. Good job! (17 ignored, 93 suppressed)
```

`yamllint`, `actionlint`, `check-yaml`, `Validate GitHub Actions` and
`Validate GitHub Workflows` pre-commit hooks pass.