### PR TITLE
CI: Add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -1,0 +1,38 @@
+---
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: "OpenSSF Scorecard"
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "50 4 * * 0"
+  push:
+    branches: ["main", "master"]
+
+# Declare default permissions as none.
+permissions: {}
+
+jobs:
+  openssf-scorecard:
+    name: "OpenSSF Scorecard"
+    # yamllint disable-line rule:line-length
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@fd3c1b43bc919e9e70787b009ffa2768ddbb1267  # v0.7.2
+    permissions:
+      contents: read  # Read repository contents (checkout, etc.)
+      # yamllint disable-line rule:line-length
+      security-events: write  # Upload results to the code-scanning dashboard
+      id-token: write  # Publish results and obtain Scorecard badge via OIDC
+      # Uncomment the permission below if installing in a private repository.
+      # actions: read


### PR DESCRIPTION
## Summary

Adds the standard OpenSSF Scorecard **thin caller** workflow
(`.github/workflows/openssf-scorecard.yaml`) so this repository joins
the organisation-wide Scorecard programme, matching the workflow
already deployed across the other `lfreleng-actions` repositories.

- Pinned to the shared reusable
  `lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml`
  at the **v0.7.2** release commit
  (`fd3c1b43bc919e9e70787b009ffa2768ddbb1267`).
- The reusable keeps `step-security/harden-runner` in **block** mode
  via a curated egress allow-list scoped to the endpoints Scorecard
  needs (including `api.deps.dev`), so it satisfies the upstream
  `ossf/scorecard-action` workflow restrictions and publishes results
  cleanly to the Security dashboard and scorecard.dev.
- Default job permissions are `none`; the job requests only
  `contents: read`, `security-events: write` and `id-token: write`,
  each documented with an inline comment.

## Validation

- `zizmor --persona=auditor --min-severity low` → **No findings to
  report.**
- `prek run` → yamllint, actionlint, REUSE, workflow validators pass.

New file uses the current year (2026) in its SPDX header.

---

This is the **template PR** for a bulk rollout of the Scorecard caller
to the remaining `lfreleng-actions` repositories. Once reviewed and
approved, the same change will be raised across the batch.
